### PR TITLE
Add pre analysis of file import

### DIFF
--- a/include/global_variable.h
+++ b/include/global_variable.h
@@ -1,10 +1,14 @@
 
 #include <vector>
 #include <string>
+#include "ast.h"
 
 
 /// T ==> The input source file list
 extern std::vector<std::string> InputFileList;
+
+/// T ==> The list of program ast node
+extern std::vector<ProgramAST*> ProgramList;
 
 /// T ==> The output file name
 extern std::string OutputFileName;
@@ -14,3 +18,7 @@ extern bool PrintIR;
 
 /// T ==> The print ast flag
 extern bool PrintAST;
+
+/// T ==> Use multi thread compile
+extern bool UseMultThreadCompile;
+extern int ThreadCount;

--- a/include/parser.h
+++ b/include/parser.h
@@ -5,7 +5,6 @@
 #include "token.h"
 #include "ast.h"
 
-void unitTest(const char* filepath);
 
 
 

--- a/include/pre_analysis.h
+++ b/include/pre_analysis.h
@@ -1,0 +1,19 @@
+
+
+/// -------------------------------------------------------------
+/// @brief This function parse input sources file list
+/// create the top ProgramAST node, and analysis the dependence
+/// of the program file. 
+/// @return if program' defpendence is a DAG return true, if not
+/// return false
+/// -------------------------------------------------------------
+bool preFileDepAnalysis();
+
+
+
+
+
+
+
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LLVM_LINK_COMPONENTS
 link_directories(${LLVM_LIBRARY_DIRS})
 
 set(SRC_FILE 
+             pre_analysis.cpp
              global_variable.cpp
              ast.cpp
              parser.cpp 

--- a/src/global_variable.cpp
+++ b/src/global_variable.cpp
@@ -5,11 +5,18 @@
 /// T ==> The input source file list
 std::vector<std::string> InputFileList;
 
+/// T ==> The list of program ast node
+std::vector<ProgramAST*> ProgramList;
+
 /// T ==> The output file name
 std::string OutputFileName;
 
 /// T ==> The print ir flag
-bool PrintIR;
+bool PrintIR = false;
 
 /// T ==> The print ast flag
-bool PrintAST;
+bool PrintAST = false;
+
+/// T ==> Use multi thread compile
+bool UseMultThreadCompile = false;
+int ThreadCount = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,10 @@
 
 
+#include "global_variable.h"
+#include "pre_analysis.h"
 #include "cxxopts.hpp"
 #include "parser.h"
-#include "global_variable.h"
+
 
 #include <memory>
 #include <iostream>
@@ -32,7 +34,8 @@ int parseCmdArgs(int argc, char *argv[]) {
             ("print-ir", "Print ir generation message", cxxopts::value<bool>()->default_value("false"))
             ("print-ast", "Print ast of source file", cxxopts::value<bool>()->default_value("false"))
             ("o, output", "Output file name", cxxopts::value<std::string>()->default_value("a.out"))
-            ("h, help", "Print help");
+            ("h, help", "Print help")
+            ("j", "Mult thread compile", cxxopts::value<int>()->default_value("1"));
     
         auto result = options.parse(argc, argv);
 
@@ -58,6 +61,12 @@ int parseCmdArgs(int argc, char *argv[]) {
             PrintIR = true;
         }
 
+        ThreadCount = result["j"].as<int>();
+        if(ThreadCount > 1) {
+            UseMultThreadCompile = true;
+            std::cout << "Use mult thread compile. core thread : " << ThreadCount << std::endl;
+        }
+
         OutputFileName = result["output"].as<std::string>();
 
         return 0;
@@ -73,12 +82,16 @@ int parseCmdArgs(int argc, char *argv[]) {
 int main(int argc, char *argv[]) {
     /// parse command line option
     if(parseCmdArgs(argc, argv)) {
+        std::cerr << "Exit with error!" << std::endl;
         return 1;
     }
     
     /// Pre Analysis
+    if(!preFileDepAnalysis()) {
+        std::cerr << "Exit with error!" << std::endl;
+        return 1;
+    }
     
 
-
-    ///  
+    /// 
 }

--- a/src/pre_analysis.cpp
+++ b/src/pre_analysis.cpp
@@ -1,0 +1,164 @@
+
+
+#include <map>
+#include <iostream>
+#include <cstring>
+#include <regex.h>
+
+#include "pre_analysis.h"
+#include "global_variable.h"
+
+
+static int CurrentIndex = 0;
+static FILE *Fp = nullptr;
+static ProgramAST *CurProg = nullptr;
+static std::map<std::string, ProgramAST *> ProgMap;
+static std::vector<std::string> FileNameList;
+static regex_t Regex;
+static char Pattern[] = "[ ]*import[ ]*\"([a-zA-Z0-9_]+.k)\"[ ]*;";
+
+static inline bool init() {
+    int ret = regcomp(&Regex, Pattern, REG_EXTENDED);
+    if(ret) {
+        std::cerr << "Can not init regex expr!" << std::endl;
+        return false;
+    }
+    return true; 
+}
+
+static inline void close() {
+    if(Fp)
+        fclose(Fp);
+    regfree(&Regex);
+    InputFileList = FileNameList;
+    FileNameList.clear();
+    ProgMap.clear();
+}
+
+static inline ProgramAST* getOrCreateProgAST(const std::string& file) {
+    if(ProgMap.find(file) == ProgMap.end()) {
+        ProgramAST *prog = new ProgramAST({CurrentIndex, 0, 0});
+        FileNameList.push_back(file);
+        ProgramList.push_back(prog);
+        CurrentIndex++;
+        ProgMap.insert({file, prog});
+    }
+    return ProgMap[file];
+}
+
+static void getIncludeFileName(char *s) {
+    regmatch_t matches[2];
+    int offset = 0, start, end, length;
+    char *file = nullptr;
+    while(regexec(&Regex, s+offset, 2, matches, 0) == 0) {
+        start = matches[1].rm_so;
+        end = matches[1].rm_eo;
+
+        if(start != -1 && end != -1) {
+            length = end - start;
+            file = (char*)malloc((length + 1) * sizeof(char));
+            file[length] = '\0'; 
+            strncpy(file, s+offset+start, length);
+            CurProg->addDependentProg(getOrCreateProgAST(file));
+            free(file);
+            file = nullptr;
+        }
+
+        offset += matches[0].rm_eo;
+    }
+}
+
+
+static inline void anaFileDepAndCreateProgramAST() {
+    static char File[512];
+    while((fgets(File, sizeof(File), Fp)) != NULL) {
+        getIncludeFileName(File);
+        memset(File, 0, sizeof(File));
+    }
+}
+
+
+static std::vector<ProgramAST*> DagCheckStack; 
+
+static inline bool depCheck(ProgramAST *prog) {
+    for(auto *p : DagCheckStack) {
+        if(p == prog) {
+            DagCheckStack.push_back(prog);
+            return false;
+        }
+    }
+
+    DagCheckStack.push_back(prog);
+
+    for(auto *p : prog->getDependentProgs()) {
+        if(!depCheck(p))
+            return false;
+    }
+
+    DagCheckStack.pop_back();
+
+    return true;
+}
+
+/// @brief Check the reference for rings
+static inline bool depCheck() {
+    for(const auto& prog : ProgramList) {
+        DagCheckStack.clear();
+        if(!depCheck(prog)) return false;
+    }
+    return true;
+}
+
+static inline void logRefError() {
+    auto it1 = DagCheckStack.begin();
+    auto it2 =  DagCheckStack.begin()+1;
+    auto end = DagCheckStack.end();
+    std::cerr << "There are circular references in the source code and compilation order cannot be determined!" << std::endl;
+    while(it2 != end) {
+        std::cerr << InputFileList[(*it1)->getLineNo()->FileIndex] << " import " << InputFileList[(*it2)->getLineNo()->FileIndex] << std::endl;
+        it1 ++;
+        it2 ++;
+    }
+}
+
+bool preFileDepAnalysis() {
+    
+    if(!init()) {
+        close();
+        return false;
+    }
+
+    CurrentIndex = 0;
+
+    Fp = nullptr;
+    CurProg = nullptr;
+
+    for(const auto& file : InputFileList) {
+        Fp = fopen(file.c_str(), "rt+");
+        
+        if(!Fp) {
+            std::cerr << "Can not find this file " << file << "." << std::endl;
+            close();
+            return false;
+        }
+
+        CurProg = getOrCreateProgAST(file);
+    
+        anaFileDepAndCreateProgramAST();
+
+        fclose(Fp);
+        Fp = nullptr;
+    }
+
+    close();
+
+    if(!depCheck()) {
+        logRefError();
+        return false;
+    }
+
+    return true;
+}
+
+
+


### PR DESCRIPTION
I add the feature of analysis file import, for example t1 import t2, t2 import t3, t3 import t1, This form of reference is not allowed. because has circular reference, it can't confirm the compile order. so i add the feature, before compile sources, it will analysis the import relationship of source file list. if has circular reference, will exit with error.